### PR TITLE
External plugin system proposal (work in progress.)

### DIFF
--- a/assets/base.html
+++ b/assets/base.html
@@ -87,9 +87,11 @@
         h('title', title)
       )
 
-      document.documentElement.replaceChild(h('body', [
-        rootView(config, data)
-      ]), document.body)
+      rootView(config, data).then(view => {
+        document.documentElement.replaceChild(h('body', [
+          view
+        ]), document.body)
+      })
     })
 
   </script>

--- a/lib/depject/external-plugins/index.js
+++ b/lib/depject/external-plugins/index.js
@@ -1,0 +1,33 @@
+const path = require('path')
+const fs = require('fs/promises')
+const homedir = require('os').homedir();
+const _ = require('lodash')
+
+function extractDepjectFields(module) {
+    return {
+        needs: module.needs,
+        gives: module.gives,
+        create: module.create
+    }
+}
+
+function loadPlugins(pluginPath, pluginDirectoryNames) {    
+    const pluginDepjectModules = pluginDirectoryNames
+        .map(pluginFolder => require(path.resolve(path.resolve(pluginPath, pluginFolder), 'index.js')))
+        
+    const modules = pluginDepjectModules.map(extractDepjectFields)
+    const allModules = _.reduce(modules, _.merge, {})
+
+    return allModules
+}
+
+module.exports = async () => {
+    const pluginPath = path.resolve(homedir, '.poncho-external-plugins');
+
+    return fs.readdir(pluginPath, 'UTF-8')
+        .then(directories => loadPlugins(pluginPath, directories))
+        .catch(error => {
+            console.log(`Error while loading external plugin: ${error}`)
+            return {}
+        })
+}

--- a/lib/depject/index.js
+++ b/lib/depject/index.js
@@ -1,3 +1,5 @@
+const addExternalPlugins = require("./external-plugins")
+
 module.exports = {
   patchwork: {
     about: {

--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -22,6 +22,7 @@ const fs = require("fs");
 const customScripts = require("./depject/scripts/lua/custom-scripts.js");
 const { isFeatureEnabled } = require("../lib/features.js");
 const { configurationForIdentity } = require("../lib/identities.js");
+const addExternalPlugins = require("./depject/external-plugins/index.js");
 
 const localTimezone = moment.tz.guess();
 moment.tz.setDefault(localTimezone);
@@ -35,13 +36,16 @@ const requireStyle = (moduleName, specificFilePath = false) => {
   return urlStr;
 };
 
-module.exports = function (config) {
+module.exports = async function (config) {
+  const externalPlugins = await addExternalPlugins()
+
   const sockets = combine(
     overrideConfig(config),
     addCommand("app.navigate", navigate),
     addCommand("app.refresh", refresh),
+    externalPlugins,
     require("./depject"),
-    require("patch-settings"),
+    require("patch-settings")
   );
 
   const api = entry(
@@ -69,6 +73,7 @@ module.exports = function (config) {
       "scripts.lua.environment.init": "first",
       "scripts.lua.environment.call": "first",
       "scripts.lua.environment.has": "first",
+      "poncho.external.plugin.menu.item": "map"
     }),
   );
 
@@ -471,6 +476,11 @@ module.exports = function (config) {
         ],
       },
       {
+        type: "submenu",
+        label: i18n("Plugins"),
+        submenu: getExternalPlugins(api),
+      },
+      {
         type: "normal",
         label: i18n("Blog Posts"),
         target: "/blogs",
@@ -529,6 +539,20 @@ module.exports = function (config) {
 
     const filteredItems = dropTabItems.filter((x) => x !== null);
     return filteredItems;
+  }
+
+  function getExternalPlugins(api) {
+    try {
+      return api.poncho.external.plugin.menu.item().map(item => ({
+        type: "normal",
+        label: item.label,
+        target: item.route
+      }))
+    } catch(e) {
+      console.log("No external plugins to load.")
+
+      return []
+    }
   }
 
   function dropTab(title) {

--- a/locales/de.json
+++ b/locales/de.json
@@ -303,5 +303,6 @@
 	"Okay, looks like you're getting it. One last one then:\nIf any of this goes wrong, who can most likely help you?\n* The patchwork devs\n* The manyverse devs\n* Nobody": "Okay, looks like you're getting it. One last one then:\nIf any of this goes wrong, who can most likely help you?\n* The patchwork devs\n* The manyverse devs\n* Nobody",
 	"nobody": "nobody",
 	"Congrats, you made it. Here your mnemonic representation of your secret:": "Congrats, you made it. Here your mnemonic representation of your secret:",
-	"Again: be very careful with it. Keep it secret, and don't use this key on multiple devices, including this one.": "Again: be very careful with it. Keep it secret, and don't use this key on multiple devices, including this one."
+	"Again: be very careful with it. Keep it secret, and don't use this key on multiple devices, including this one.": "Again: be very careful with it. Keep it secret, and don't use this key on multiple devices, including this one.",
+	"Plugins": "Plugins"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -437,5 +437,6 @@
 	"Poncho Wonky of ": "Poncho Wonky of ",
 	"Edit": "Edit",
 	"Edit Post": "Edit Post",
-	"Edit your post": "Edit your post"
+	"Edit your post": "Edit your post",
+	"Plugins": "Plugins"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1174,6 +1174,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1195,6 +1196,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1214,6 +1216,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1224,7 +1227,8 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.2.2",
@@ -1928,7 +1932,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
       "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2005,7 +2008,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4667,7 +4669,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "4.0.2",
@@ -4913,7 +4916,8 @@
     "node_modules/depject": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/depject/-/depject-4.1.1.tgz",
-      "integrity": "sha1-6/ciCGgsEfx9BRIjxG6223jVYFg=",
+      "integrity": "sha512-DWu0MFNGSRzTOoIUM90VjSbwmeB3vgSthkwIIE5MKDZcT1T2QlpV1f5GjPUs+CnQsKeC0yB7njsa4apJ74Hiww==",
+      "license": "MIT",
       "dependencies": {
         "libnested": "^1.1.0"
       },
@@ -5060,7 +5064,6 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",
@@ -5358,7 +5361,6 @@
       "integrity": "sha512-0OKLiymqfV0WK68RBXqAm3Myad2TpI5wwxLCBEUcH5Nugo3YfSk7p1Js/AL9266qTz5xZioUnxt9hG8FFwax0g==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -5744,6 +5746,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5764,6 +5767,7 @@
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5782,6 +5786,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5796,7 +5801,8 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron/node_modules/@types/node": {
       "version": "24.12.0",
@@ -6228,7 +6234,6 @@
       "integrity": "sha512-uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.2.1",
@@ -6388,7 +6393,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
       "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.1",
         "array.prototype.flat": "^1.2.3",
@@ -6442,7 +6446,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
       "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "eslint-plugin-es": "^3.0.0",
         "eslint-utils": "^2.0.0",
@@ -6472,7 +6475,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6482,7 +6484,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
       "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.1",
         "array.prototype.flatmap": "^1.2.3",
@@ -11962,6 +11963,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -11979,6 +11981,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -11995,7 +11998,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -13631,7 +13633,6 @@
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.3.2.tgz",
       "integrity": "sha512-D46+4LWwsM1LnO4dg6FM/MfGmMk9uYsIcDElqyNeImBnyUueKi2xz10CHF9iSAtSUGReQDV4SCVUiVrPnaKnsA==",
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.0",
         "hoox": "0.0.1",
@@ -16453,6 +16454,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -16517,6 +16519,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -16538,6 +16541,7 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16548,6 +16552,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -16562,6 +16567,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },


### PR DESCRIPTION
Palaroonie,

First of all - thanks for resurrecting patchwork (my favourite client :D.)

Second of all - awrite, howzitgaun? Long time no speak, hope you're well! Sorry for being a stranger.

Thirdly:

Are you interested in adding an external plugin system to Patchwork at all? :sweat_smile: .

In the spirit of your README:

> depject is a bespoke dependency injection system, which breaks any kind of navigation and tool support for debugging.

I have a computer and I can't be stopped!

If we're going to have a strange bespoke dependency injection system, wouldn't it be nice to take advantage of it? It gives us an opportunity to (in external plugins) 'hook' into various things that are already in Patchwork (or expand them to be more hookable) such as:

* The navigation and rendering system to add new routes (already present.)
* The menu system to add new navigation menus and context menu options. I had to add some code for this - we could do similar for various context menus such as when right clicking a user to add new options such as 'invite to chess game.'

My motivation was popping by the scuttleverse for the first time in ages and wanting to have a home for ssb-chess but not feeling like it's currently in nice enough shape for Patchwork (it looks a bit ugly :sweat_smile: ) or that it might not be fitting with the theme of Patchwork functionality.

I figured it wouldn't be that hard to add a plugin system to allow people to optionally add it if they wanted it despite it being rough around the edges. I also thought it might be a useful thing to have for Patchwork customisations, prototypes, etc.

I made an ssb-chess proof of concept here: https://github.com/Happy0/ssb-chess-poncho-plugin-experiment . If on this branch and the plugin is put in the `~/.ssb/.poncho-external-plugins` and `npm install` is ran in the directory, it should appear under a `plugins` menu in poncho wonky / patchwork :sweat_smile: .

<img width="3840" height="1998" alt="chess-plugin" src="https://github.com/user-attachments/assets/388b9979-57e4-4193-86e5-b66946a2b50f" />

(Aside: I'm not sure why running 'peek' lagged my computer in the above screen record :sweat_smile: .)

Are you interested? If not, I won't be offended! I know it's a potential maintenance burden (especially if you want to heed the old guard's advice of getting rid of depject) and adds an attack surface area security wise (I know you're working on a lua scripting system which can be sandboxed)  :sweat_smile: .

If you are interested I think the next steps are:

* Add a UI for managing plugins and adding new ones as a zip
* Add guard against poncho wonky crashing completely if it can't load the plugins (fall back to combining the depject modules without the external plugins.)
* Finish updating locale files for the word 'plugin' :sweat_smile: 
* Investigate `TypeError: rootView(...).then is not a function` error in logs on start up.
* ssb-chess plugin: work how how to stop patchwork tooltip when hovering over links, fix invite menu not being populated :sweat_smile: 